### PR TITLE
A principal alteração foi na função "buildUrlByRule", 

### DIFF
--- a/Meli-Scrap.js
+++ b/Meli-Scrap.js
@@ -17,9 +17,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // ====== CONFIG ======
-const DEFAULT_IDS_FILE  = "C:\\Users\\lfcar\\OneDrive\\Desktop\\mlb\\mlb_ids.txt";
-const DEFAULT_CSV_PATH  = "C:\\Users\\lfcar\\OneDrive\\Desktop\\mlb\\saida.csv";
-const DEFAULT_JSON_PATH = "C:\\Users\\lfcar\\OneDrive\\Desktop\\mlb\\saida.json";
+const DEFAULT_IDS_FILE  = "D:\\Trabaio\\Meli\\Meli-scarp\\mlb_ids.txt";
+const DEFAULT_CSV_PATH  = "D:\\Trabaio\\Meli\\Meli-scarp\\mlb\\saida.csv";
+const DEFAULT_JSON_PATH = "D:\\Trabaio\\Meli\\Meli-scarp\\mlb\\saida.json";
 const HEADLESS = true;
 const MAX_WAIT_MS = 12000;
 const PAUSE_MS = [900, 2500];
@@ -85,13 +85,21 @@ async function waitAny(page, selectors, timeout = MAX_WAIT_MS) {
 
 /** Links por regra:
  * MLBU##########  -> http://mercadolivre.com.br/aaa/up/MLBU##########
- * MLB##########   -> https://produto.mercadolivre.com.br/MLB-##########
+ * MLB##########   -> Verifica comprimento para decidir formato da URL
  */
 function buildUrlByRule(itemId) {
     const id = itemId.trim().toUpperCase();
     if (id.startsWith("MLBU")) return `http://mercadolivre.com.br/aaa/up/${id}`;
     if (id.startsWith("MLB-")) return `https://produto.mercadolivre.com.br/${id}`;
-    if (id.startsWith("MLB")) return `https://produto.mercadolivre.com.br/MLB-${id.slice(3)}`;
+    if (id.startsWith("MLB")) {
+        // Verifica comprimento para determinar formato da URL
+        const numPart = id.slice(3);
+        if (numPart.length <= 8) {
+            return `http://mercadolivre.com.br/aaa/p/${id}`;
+        } else {
+            return `https://produto.mercadolivre.com.br/MLB-${numPart}`;
+        }
+    }
     return null;
 }
 


### PR DESCRIPTION
onde adicionei uma verificação de comprimento para a parte numérica do ID. Agora:

IDs com 7 ou 8 dígitos após "MLB" usam o formato sem traço

IDs com 9 ou mais dígitos usam o formato com traço

Isso resolve tanto para casos como "MLB36957219" (8 dígitos) quanto "MLB2783711944" (9 dígitos).